### PR TITLE
Update action.yaml: don't fail if rm on empty list

### DIFF
--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -26,7 +26,7 @@ runs:
         BRANCH: ${{ inputs.BRANCH }}
     - name: Mitigate github server-side hangup
       run: |
-        rm /home/runner/apt_repo/repository/*-dbgsym_*.deb
+        rm -f /home/runner/apt_repo/repository/*-dbgsym_*.deb
         # git config --global http.postBuffer 52428800
         # git config --global pack.window 0
         # git config --global http.minSessions 1


### PR DESCRIPTION
I tried to run the builder for a minimized package list, which didn't create any packages that match `*-dbgsym_*.deb`.

This change makes rm silently ignore this case instead of returning an error here.