### PR TITLE
fix to pass packages with catkin_virtualenv

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -159,6 +159,10 @@ build_deb(){
   SBUILD_OPTS="--chroot-mode=unshare --no-clean-source --no-run-lintian \
     --dpkg-source-opts=\"-Zgzip -z1 --format=1.0 -sn\" --build-dir=$REPO --extra-package=$REPO \
     $EXTRA_SBUILD_OPTS"
+
+  # create logger directgory for venv
+  SBUILD_OPTS="$SBUILD_OPTS --chroot-setup-commands='mkdir -p /sbuild-nonexistent/.ros/log/; chmod a+rw -R /sbuild-nonexistent/'"
+
   # dpkg-source-opts: no need for upstream.tar.gz
   eval sbuild $SBUILD_OPTS
   sbuild_success=$?

--- a/build.sh
+++ b/build.sh
@@ -148,6 +148,8 @@ build_deb(){
   # all use the "debian" term, but we want this distribution to be called "one" instead
   sed -i 's@ros-debian-@ros-one-@' $(grep -rl 'ros-debian-' debian/)
   sed -i 's@/opt/ros/debian@/opt/ros/one@g' debian/rules
+  # skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries
+  sed -i '/dh_shlibdeps / s@$@ || echo "Skip dh_shlibdeps error!!!"@' debian/rules
 
   sed -i "1 s@([^)]*)@($pkg_version)@" debian/changelog
 

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ case $ROS_DISTRO in
     ;;
 esac
 
-EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(echo $DEB_REPOSITORY | sed -n '/^ *$/ T; s/.*/--extra-repository="\0"/; p' | tr '\n' ' ')"
+EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(/usr/bin/echo -e "$DEB_REPOSITORY" | sed -n '/^ *$/ T; s/^ *\(.*\)/--extra-repository="\1"/; p' | tr '\n' ' ')"
 
 # jammy does not have python3-catkin-tools (noble has catkin-tools)
 curl -sSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xcad670483add74b8c77e4512c3263a3eba4c7747' -o /home/runner/ppa-k-okada-keyring.gpg

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,10 @@ esac
 
 EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(echo $DEB_REPOSITORY | sed -n '/^ *$/ T; s/.*/--extra-repository="\0"/; p' | tr '\n' ' ')"
 
+# jammy does not have python3-catkin-tools (noble has catkin-tools)
+curl -sSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xcad670483add74b8c77e4512c3263a3eba4c7747' -o /home/runner/ppa-k-okada-keyring.gpg
+EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS --extra-repository='deb https://ppa.launchpadcontent.net/k-okada/python3-catkin-tools/ubuntu $DEB_DISTRO main' --extra-repository-key=/home/runner/ppa-k-okada-keyring.gpg"
+
 # make output directory
 REPO_DEPENDENCIES=/home/runner/apt_repo_dependencies
 REPO=/home/runner/apt_repo

--- a/build.sh
+++ b/build.sh
@@ -154,6 +154,8 @@ build_deb(){
   sed -i 's@/opt/ros/debian@/opt/ros/one@g' debian/rules
   # skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries
   sed -i '/dh_shlibdeps / s@$@ || echo "Skip dh_shlibdeps error!!!"@' debian/rules
+  # ignore dh_strip error, from jammy, 'objcopy' added '--compress-debug-sections' and this cause error on 'numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so has a corrupt string table index - ignoring'
+  echo -e 'override_dh_strip:\n	dh_strip || true\n' |tee -a debian/rules
 
   sed -i "1 s@([^)]*)@($pkg_version)@" debian/changelog
 

--- a/build.sh
+++ b/build.sh
@@ -169,6 +169,9 @@ build_deb(){
   # create logger directgory for venv
   SBUILD_OPTS="$SBUILD_OPTS --chroot-setup-commands='mkdir -p /sbuild-nonexistent/.ros/log/; chmod a+rw -R /sbuild-nonexistent/'"
 
+  # Canonical dropped the Debian ROS packages from 24.04 for political reasons. Wow.
+  test "$DEB_DISTRO" = "noble" && SBUILD_OPTS="$SBUILD_OPTS --extra-repository=\"deb [trusted=yes] https://ppa.launchpadcontent.net/v-launchpad-jochen-sprickerhof-de/ros/ubuntu $DEB_DISTRO main\""
+
   # dpkg-source-opts: no need for upstream.tar.gz
   eval sbuild $SBUILD_OPTS
   sbuild_success=$?


### PR DESCRIPTION
here is the list of fixes to pass jsk packages.

- ecc7df2 fix when multiple repository is defined in DEB_REPOSITORY, --extra-repository takes only one url. To use multiple repositories, we need to pass --extra-repository multiple times
--> support multiple DEB_REPOSITORY options. This fix is not related jsk nor catkin_virtualenv. 
```
          DEB_REPOSITORY: |
            deb [trusted=yes] ${{ env.UPSTREAM }} ./
            deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository ./
            deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_3rdparty-jammy-one/repository ./
            deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_roseus-jammy-one/repository ./
```
https://github.com/k-okada/ros-o-overlay/blob/5d361a9146e8aaad465b9e78762b24163c737027/.github/workflows/build-overlay.yaml#L31-L35


- 28b8a36 skip dh_strip error to ignore --compress-debug-sections error
--> Some pip packages download binary files for multiple architecture including win32/macos, and `dh_strip` command causes error. The reason we do not need this fix in Noetic is that Debian added added `--compress-debug-sections` option in `objcopy' command from Jammy

- 7bb7eb3 add ppa:k-okada/python3-catkin-tools for jammy
--> catkin-tools package is not releasd on jammy. It is very interesting that on Noble, they have `catkin-tools` package. We could move this deb files to more convinient locations, such as ppa:v-launchpad-jochen-sprickerhof-de/ros ?

- b3bab5c 'mkdir /sbuild-nonexistent/.ros/log' to resolve ros-o-builder error with catkin_virtual_env
--> Pip packages uses ROS_LOG_DIR file and we need to create the directory.

- b3cb377 build.sh : skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries
--> same reason as  28b8a36


