### PR TITLE
add ppa:v-launchpad-jochen-sprickerhof-de/ros for 22.04

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -157,6 +157,10 @@ build_deb(){
   SBUILD_OPTS="--chroot-mode=unshare --no-clean-source --no-run-lintian \
     --dpkg-source-opts=\"-Zgzip -z1 --format=1.0 -sn\" --build-dir=$REPO --extra-package=$REPO \
     $EXTRA_SBUILD_OPTS"
+
+  # Canonical dropped the Debian ROS packages from 24.04 for political reasons. Wow.
+  test "$DEB_DISTRO" = "noble" && SBUILD_OPTS="$SBUILD_OPTS --extra-repository=\"deb [trusted=yes] https://ppa.launchpadcontent.net/v-launchpad-jochen-sprickerhof-de/ros/ubuntu $DEB_DISTRO main\""
+
   # dpkg-source-opts: no need for upstream.tar.gz
   eval sbuild $SBUILD_OPTS
   sbuild_success=$?


### PR DESCRIPTION
@v4hn Fixes to build ROS-O packages for 24.04. As described in `prepare.sh`, Canonical dropped ROS packages and we need to add `ppa:v-launchpad-jochen-sprickerhof-de/ros` WITHIN the sbuild environment.

I have confarmed if this works on -> https://github.com/k-okada/ros-o-builder/actions/runs/12686663933/job/35360160153
