### PR TITLE
Support ARM architecture

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -45,7 +45,7 @@ mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates,git \
   --customize-hook='chroot "$1" update-ccache-symlinks' \
   --components=main,universe \
   "$DEB_DISTRO" \
-  "$HOME/.cache/sbuild/$DEB_DISTRO-arm64.tar"
+  "$HOME/.cache/sbuild/$DEB_DISTRO-$(dpkg --print-architecture).tar"
 
 ccache --zero-stats --max-size=10.0G
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -45,7 +45,7 @@ mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates,git \
   --customize-hook='chroot "$1" update-ccache-symlinks' \
   --components=main,universe \
   "$DEB_DISTRO" \
-  "$HOME/.cache/sbuild/$DEB_DISTRO-amd64.tar"
+  "$HOME/.cache/sbuild/$DEB_DISTRO-arm64.tar"
 
 ccache --zero-stats --max-size=10.0G
 


### PR DESCRIPTION
@v4hn I'm trying to support ROS-O for ARM processors. 
This PR dynamically set architecture from the current environment where the architecture of the cpu is specified.

Based on this PR, I have checked that ros-o for both amd64 and arm64 can be built to some degree. 
amd64: https://github.com/sugikazu75/ros-o-builder/actions/runs/12883298101
arm64: https://github.com/sugikazu75/ros-o-builder/actions/runs/12882627292

Results
amd64: https://github.com/sugikazu75/ros-o-builder/tree/jammy-one-unstable
arm64: https://github.com/sugikazu75/ros-o-builder/tree/jammy-arm64-one-unstable
