### PR TITLE
fix error when passing multple url in DEB_REPOSITORY

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ case $ROS_DISTRO in
     ;;
 esac
 
-EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(echo $DEB_REPOSITORY | sed -n '/^ *$/ T; s/.*/--extra-repository="\0"/; p' | tr '\n' ' ')"
+EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(/usr/bin/echo -e "$DEB_REPOSITORY" | sed -n '/^ *$/ T; s/^ *\(.*\)/--extra-repository="\1"/; p' | tr '\n' ' ')"
 
 # make output directory
 REPO_DEPENDENCIES=/home/runner/apt_repo_dependencies


### PR DESCRIPTION
fix when multiple repository is defined in DEB_REPOSITORY, --extra-repository takes only one url. To use multiple repositories, we need to pass --extra-repository multiple times

you can reproduce the error by
```
export DEB_REPOSITORY='                                                                                           
            deb [trusted=yes] ${{ env.UPSTREAM }} ./                                                              
            deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy\
-one/repository ./                                                                                                
deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/reposit\
ory2 ./                                                                                                           
'

echo "=== DEB_REPOSITORY ==="
echo "$DEB_REPOSITORY"
echo "======================"

EXTRA_SBUILD_OPTS=''
EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(echo $DEB_REPOSITORY | sed -n '/^ *$/ T; s/.*/--extra-repository="\0"/; p\
' | tr '\n' ' ')"
echo "=== EXTRA_SBUILD_OPTS ==="
echo "$EXTRA_SBUILD_OPTS"
echo "========================="

EXTRA_SBUILD_OPTS=''
EXTRA_SBUILD_OPTS="$EXTRA_SBUILD_OPTS $(/usr/bin/echo -e "$DEB_REPOSITORY" | sed -n '/^ *$/ T; s/^ *\(.*\)/--extr\
a-repository="\1"/; p' | tr '\n' ' ')"
echo "=== EXTRA_SBUILD_OPTS ==="
echo "$EXTRA_SBUILD_OPTS"
echo "========================="
```
and the output is
```
=== DEB_REPOSITORY ===

            deb [trusted=yes] ${{ env.UPSTREAM }} ./
            deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository ./
deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository2 ./

======================
=== EXTRA_SBUILD_OPTS ===
 --extra-repository="deb [trusted=yes] ${{ env.UPSTREAM }} ./ deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository ./ deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository2 ./"
=========================
=== EXTRA_SBUILD_OPTS ===
 --extra-repository="deb [trusted=yes] ${{ env.UPSTREAM }} ./" --extra-repository="deb [trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository ./" --extra-repository="deb
[trusted=yes] https://raw.githubusercontent.com/k-okada/ros-o-overlay/check_jsk_recognition-jammy-one/repository2
./"
=========================
```
we need '--extra-repository` for all urls.
