### PR TITLE
suppport package using catkin_virtual_env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -159,6 +159,10 @@ build_deb(){
   SBUILD_OPTS="--chroot-mode=unshare --no-clean-source --no-run-lintian \
     --dpkg-source-opts=\"-Zgzip -z1 --format=1.0 -sn\" --build-dir=$REPO --extra-package=$REPO \
     $EXTRA_SBUILD_OPTS"
+
+  # create logger directgory for venv
+  SBUILD_OPTS="$SBUILD_OPTS --chroot-setup-commands='mkdir -p /sbuild-nonexistent/.ros/log/; chmod a+rw -R /sbuild-nonexistent/'"
+
   # dpkg-source-opts: no need for upstream.tar.gz
   eval sbuild $SBUILD_OPTS
   sbuild_success=$?

--- a/build.sh
+++ b/build.sh
@@ -148,6 +148,8 @@ build_deb(){
   # all use the "debian" term, but we want this distribution to be called "one" instead
   sed -i 's@ros-debian-@ros-one-@' $(grep -rl 'ros-debian-' debian/)
   sed -i 's@/opt/ros/debian@/opt/ros/one@g' debian/rules
+  # skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries
+  sed -i '/dh_shlibdeps / s@$@ || echo "Skip dh_shlibdeps error!!!"@' debian/rules
 
   sed -i "1 s@([^)]*)@($pkg_version)@" debian/changelog
 

--- a/build.sh
+++ b/build.sh
@@ -150,6 +150,8 @@ build_deb(){
   sed -i 's@/opt/ros/debian@/opt/ros/one@g' debian/rules
   # skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries
   sed -i '/dh_shlibdeps / s@$@ || echo "Skip dh_shlibdeps error!!!"@' debian/rules
+  # ignore dh_strip error, from jammy, 'objcopy' added '--compress-debug-sections' and this cause error on 'numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so has a corrupt string table index - ignoring'
+  echo -e 'override_dh_strip:\n	dh_strip || true\n' |tee -a debian/rules
 
   sed -i "1 s@([^)]*)@($pkg_version)@" debian/changelog
 


### PR DESCRIPTION
- create /sbuild-nonexistent/.ros/log
 ```
      User Environment
      ----------------
      APT_CONFIG=/var/lib/sbuild/apt.conf
      CCACHE_DIR=/build/ccache
      DEB_BUILD_OPTIONS=nocheck
      HOME=/sbuild-nonexistent
      -- Using system site packages
      WARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.ARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.- Using virtualenv
    
        File /usr/lib/python3.10/os.py, line 225, in makedirs
          mkdir(name, mode)
      PermissionError: [Errno 13] Permission denied: '/sbuild-nonexistent'
```

Loosen dh_* command
- skip dh_shlibdeps, because some pip modules, speech_recognition for example, contains x86/x86_64/win32/mac binaries 
-  from jammy, 'objcopy' added '--compress-debug-sections' and this cause error on 'numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so has a corrupt string table index - ignoring'